### PR TITLE
Persist user progress and data across tabs

### DIFF
--- a/src/components/AchieveTab.tsx
+++ b/src/components/AchieveTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useFirebaseFocusSessions, useFirebaseGoals } from '@/hooks/useFirebaseData'
+import { useFirebaseFocusSessions, useFirebaseGoals, useFirebaseActiveFocusSession } from '@/hooks/useFirebaseData'
 import { useAuth } from '@/contexts/AuthContext'
 // Fixed async/await usage for notifications
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -42,8 +42,7 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
   // Use shared firebase-backed hooks for consistency
   const [focusSessions, setFocusSessions] = useFirebaseFocusSessions()
   const [goals, setGoals] = useFirebaseGoals()
-  // const [focusSessions, setFocusSessions] = useKV<FocusSession[]>(userDataKey('focus-sessions'), [])
-  // const [goals, setGoals] = useKV<Goal[]>(userDataKey('focus-goals'), [])
+  const [activeFocusSession, setActiveFocusSession] = useFirebaseActiveFocusSession()
   
   // Timer state
   const [isRunning, setIsRunning] = useState(false)
@@ -51,7 +50,6 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
   const [sessionTitle, setSessionTitle] = useState('')
   const [sessionCategory, setSessionCategory] = useState('')
   const [sessionNotes, setSessionNotes] = useState('')
-  const [currentSession, setCurrentSession] = useState<FocusSession | null>(null)
   
   // UI state
   const [showAddGoal, setShowAddGoal] = useState(false)
@@ -64,20 +62,43 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
     deadline: ''
   })
 
+  // Load active session on mount
+  useEffect(() => {
+    if (activeFocusSession && !activeFocusSession.completed) {
+      // Resume active session
+      const elapsed = Math.floor((Date.now() - new Date(activeFocusSession.startTime).getTime()) / 1000)
+      setCurrentTime(elapsed)
+      setSessionTitle(activeFocusSession.title)
+      setSessionCategory(activeFocusSession.category || '')
+      setSessionNotes(activeFocusSession.notes || '')
+      // Don't auto-start, let user decide to resume
+    }
+  }, []) // Only run on mount
+
   // Timer effect
   useEffect(() => {
     let interval: NodeJS.Timeout
     
-    if (isRunning && currentSession) {
+    if (isRunning && activeFocusSession) {
       interval = setInterval(() => {
-        setCurrentTime(prev => prev + 1)
+        setCurrentTime(prev => {
+          const newTime = prev + 1
+          // Update the active session with new elapsed time
+          if (activeFocusSession) {
+            setActiveFocusSession({
+              ...activeFocusSession,
+              duration: Math.floor(newTime / 60) // Update duration in minutes
+            })
+          }
+          return newTime
+        })
       }, 1000)
     }
     
     return () => {
       if (interval) clearInterval(interval)
     }
-  }, [isRunning, currentSession])
+  }, [isRunning, activeFocusSession])
 
   // Format time display
   const formatTime = (seconds: number) => {
@@ -129,7 +150,7 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
       ...(sanitizedNotes && { notes: sanitizedNotes })
     }
 
-    setCurrentSession(newSession)
+    setActiveFocusSession(newSession)
     setCurrentTime(0)
     setIsRunning(true)
     mobileFeedback.buttonPress()
@@ -144,11 +165,11 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
 
   // Stop and save session
   const stopSession = () => {
-    if (!currentSession) return
+    if (!activeFocusSession) return
 
     const sessionMinutes = Math.floor(currentTime / 60)
     const completedSession: FocusSession = {
-      ...currentSession,
+      ...activeFocusSession,
       duration: sessionMinutes, // store in minutes
       endTime: new Date(),
       completed: true
@@ -165,8 +186,8 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
       // Silent error handling for goals progress
     });
 
-    // Reset timer state
-    setCurrentSession(null)
+    // Clear active session
+    setActiveFocusSession(null)
     setCurrentTime(0)
     setIsRunning(false)
     setSessionTitle('')
@@ -542,7 +563,7 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {!currentSession ? (
+          {!activeFocusSession ? (
             <div className="space-y-4">
               <Input
                 placeholder="What are you focusing on?"
@@ -573,14 +594,30 @@ export function AchieveTab({ achievements, onUpdateAchievements }: AchieveTabPro
                 <Play size={16} className="mr-2" />
                 Start Focus Session
               </Button>
+              
+              {/* Show resume button if there's an incomplete session */}
+              {activeFocusSession && !activeFocusSession.completed && !isRunning && (
+                <div className="space-y-2">
+                  <div className="text-sm text-white/70 text-center">
+                    Or resume your previous session:
+                  </div>
+                  <Button 
+                    onClick={() => setIsRunning(true)}
+                    className="w-full bg-blue-500/20 hover:bg-blue-500/30 text-blue-400 border border-blue-500/30"
+                  >
+                    <Play size={16} className="mr-2" />
+                    Resume: {activeFocusSession.title} ({formatTime(currentTime)})
+                  </Button>
+                </div>
+              )}
             </div>
           ) : (
             <div className="text-center space-y-6">
               <div className="space-y-2">
-                <h3 className="text-2xl font-bold text-white">{currentSession.title}</h3>
-                {currentSession.category && (
+                <h3 className="text-2xl font-bold text-white">{activeFocusSession.title}</h3>
+                {activeFocusSession.category && (
                   <Badge variant="secondary" className="bg-white/20 text-white">
-                    {currentSession.category}
+                    {activeFocusSession.category}
                   </Badge>
                 )}
               </div>

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
+import { useFirebaseCalendarEvents } from '@/hooks/useFirebaseData'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogTrigger } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -35,11 +36,9 @@ export function Calendar({ subjects }: CalendarProps) {
   
   // Get user-specific data
   const currentUserId = user?.uid || 'anonymous'
-  const userDataKey = (key: string) => `${currentUserId}-${key}`
   
-  // Temporarily disabled GitHub Spark KV to prevent rate limit errors
-  const [events, setEvents] = useState<CalendarEvent[]>([])
-  // const [events, setEvents] = useKV<CalendarEvent[]>(userDataKey('calendar-events'), [])
+  // Use Firebase-backed calendar events
+  const [events, setEvents] = useFirebaseCalendarEvents()
   const [currentDate, setCurrentDate] = useState(new Date())
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
   const [isAddEventOpen, setIsAddEventOpen] = useState(false)

--- a/src/hooks/useFirebaseData.ts
+++ b/src/hooks/useFirebaseData.ts
@@ -2,7 +2,7 @@
 import { useEffect, useState, useRef } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { firestoreService } from '@/lib/firestore'
-import { Subject, StudySession, Achievement, Task, Challenge, FocusSession, Goal, StickyNote } from '@/lib/types'
+import { Subject, StudySession, Achievement, Task, Challenge, FocusSession, Goal, StickyNote, CalendarEvent } from '@/lib/types'
 import { INITIAL_ACHIEVEMENTS } from '@/lib/constants'
 import { onSnapshot, doc } from 'firebase/firestore'
 import { db, isFirebaseAvailable } from '@/lib/firebase'
@@ -331,5 +331,23 @@ export function useFirebaseTheme(): [string, (value: string | ((prev: string) =>
     'dark',
     (userId, data) => firestoreService.saveUserData(userId, 'theme', data),
     (userId) => firestoreService.getUserData<string>(userId, 'theme')
+  )
+}
+
+export function useFirebaseCalendarEvents(): [CalendarEvent[], (value: CalendarEvent[] | ((prev: CalendarEvent[]) => CalendarEvent[])) => void] {
+  return useFirebaseData<CalendarEvent[]>(
+    'calendar-events',
+    [] as CalendarEvent[],
+    (userId, data) => firestoreService.saveCalendarEvents(userId, data),
+    (userId) => firestoreService.getCalendarEvents(userId)
+  )
+}
+
+export function useFirebaseActiveFocusSession(): [FocusSession | null, (value: FocusSession | null | ((prev: FocusSession | null) => FocusSession | null)) => void] {
+  return useFirebaseData<FocusSession | null>(
+    'active-focus-session',
+    null,
+    (userId, data) => firestoreService.saveActiveFocusSession(userId, data),
+    (userId) => firestoreService.getActiveFocusSession(userId)
   )
 }

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1474,6 +1474,98 @@ export class FirestoreService {
       return { data: null, error: error.message || 'Failed to get notes' }
     }
   }
+
+  // Calendar Events Management
+  async saveCalendarEvents(userId: string, events: any[]): Promise<{ error: string | null }> {
+    if (!isFirebaseAvailable || !db) return { error: 'Firestore unavailable' }
+    try {
+      const sanitizedEvents = events.map(event => this.sanitize({
+        ...event,
+        date: event.date instanceof Date ? event.date.toISOString() : event.date
+      }))
+      
+      const userRef = doc(db, 'users', userId)
+      await setDoc(userRef, { 
+        calendarEvents: sanitizedEvents,
+        updatedAt: serverTimestamp()
+      }, { merge: true })
+      return { error: null }
+    } catch (error: any) {
+      console.error('Failed to save calendar events:', error)
+      return { error: error.message || 'Failed to save calendar events' }
+    }
+  }
+
+  async getCalendarEvents(userId: string): Promise<{ data: any[] | null; error: string | null }> {
+    if (!isFirebaseAvailable || !db) return { data: null, error: 'Firestore unavailable' }
+    try {
+      const userDoc = await getDoc(doc(db, 'users', userId))
+      if (userDoc.exists()) {
+        const data = userDoc.data()
+        if (data.calendarEvents) {
+          // Convert date strings back to Date objects
+          const events = data.calendarEvents.map((event: any) => ({
+            ...event,
+            date: event.date ? new Date(event.date) : new Date()
+          }))
+          return { data: events, error: null }
+        }
+      }
+      return { data: null, error: null }
+    } catch (error: any) {
+      console.error('Failed to get calendar events:', error)
+      return { data: null, error: error.message || 'Failed to get calendar events' }
+    }
+  }
+
+  // Active Focus Session Management
+  async saveActiveFocusSession(userId: string, session: any | null): Promise<{ error: string | null }> {
+    if (!isFirebaseAvailable || !db) return { error: 'Firestore unavailable' }
+    try {
+      const userRef = doc(db, 'users', userId)
+      if (session) {
+        const sanitizedSession = this.sanitize({
+          ...session,
+          startTime: session.startTime instanceof Date ? session.startTime.toISOString() : session.startTime
+        })
+        await setDoc(userRef, { 
+          activeFocusSession: sanitizedSession,
+          updatedAt: serverTimestamp()
+        }, { merge: true })
+      } else {
+        // Clear active session
+        await setDoc(userRef, { 
+          activeFocusSession: null,
+          updatedAt: serverTimestamp()
+        }, { merge: true })
+      }
+      return { error: null }
+    } catch (error: any) {
+      console.error('Failed to save active focus session:', error)
+      return { error: error.message || 'Failed to save active focus session' }
+    }
+  }
+
+  async getActiveFocusSession(userId: string): Promise<{ data: any | null; error: string | null }> {
+    if (!isFirebaseAvailable || !db) return { data: null, error: 'Firestore unavailable' }
+    try {
+      const userDoc = await getDoc(doc(db, 'users', userId))
+      if (userDoc.exists()) {
+        const data = userDoc.data()
+        if (data.activeFocusSession) {
+          const session = {
+            ...data.activeFocusSession,
+            startTime: data.activeFocusSession.startTime ? new Date(data.activeFocusSession.startTime) : new Date()
+          }
+          return { data: session, error: null }
+        }
+      }
+      return { data: null, error: null }
+    } catch (error: any) {
+      console.error('Failed to get active focus session:', error)
+      return { data: null, error: error.message || 'Failed to get active focus session' }
+    }
+  }
 }
 
 export const firestoreService = new FirestoreService()


### PR DESCRIPTION
Add Firebase persistence for calendar events and active focus sessions to prevent data loss on tab switches.

This PR addresses user-reported issues where calendar events and the focus session timer would reset when switching tabs. By integrating Firebase for these features, their state is now saved and restored, allowing focus sessions to resume and calendar events to remain visible across sessions.

---
<a href="https://cursor.com/background-agent%3FbcId=bc-3185e563-67e2-4a09-9208-2273111b9da1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents%3Fid=bc-3185e563-67e2-4a09-9208-2273111b9da1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>